### PR TITLE
Maximum der Vorschautage auf 48 erhöht

### DIFF
--- a/Tibber_Query/form.json
+++ b/Tibber_Query/form.json
@@ -82,11 +82,11 @@
                 
                     {   "type": "NumberSpinner",
                         "name": "HTML_Default_HourAhead",
-                        "caption": "Set how many hours you want to see, Min. 12 and Max 24",
+                        "caption": "Set how many hours you want to see, Min. 12 and Max. 48",
                         "width":"450px",
                         "digits": 0, 
                         "minimum": 12,
-                        "maximum": 24
+                        "maximum": 48
                     },
                     {   "type": "NumberSpinner",
                         "name": "HTML_Scale",

--- a/Tibber_Query/locale.json
+++ b/Tibber_Query/locale.json
@@ -75,7 +75,7 @@
             "Color for Level very expensive":"Farbe für Level sehr teuer",
             "thickness of the marker in px":"dicke der Markierung in px",
             "Reset HTML settings":"alle HTML Einstellungen zurücksetzen",
-            "Set how many hours you want to see, Min. 12 and Max 24":"legen Sie fest, wieviele Stunden sie sehen möchten. Minimum sind 12 und 24 das Maximum",
+            "Set how many hours you want to see, Min. 12 and Max. 48":"legen Sie fest, wieviele Stunden sie sehen möchten. Minimum sind 12 und 48 das Maximum",
             "no data available, please check log file for error messages.":"keine Daten Verfügbar, bitte das Logfile auf Fehler prüfen.",
             "display of prices in the bar":"Anzeige der Preise im Balken",
             "Number of decimal places":"Anzahl der Nachkommastelle",

--- a/Tibber_Query/locale.json
+++ b/Tibber_Query/locale.json
@@ -75,7 +75,7 @@
             "Color for Level very expensive":"Farbe für Level sehr teuer",
             "thickness of the marker in px":"dicke der Markierung in px",
             "Reset HTML settings":"alle HTML Einstellungen zurücksetzen",
-            "Set how many hours you want to see, Min. 12 and Max. 48":"legen Sie fest, wieviele Stunden sie sehen möchten. Minimum sind 12 und 48 das Maximum",
+            "Set how many hours you want to see, Min. 12 and Max. 48":"Legen Sie fest, wieviele Stunden (minimal 12, maximal 48) sie sehen möchten.",
             "no data available, please check log file for error messages.":"keine Daten Verfügbar, bitte das Logfile auf Fehler prüfen.",
             "display of prices in the bar":"Anzeige der Preise im Balken",
             "Number of decimal places":"Anzahl der Nachkommastelle",

--- a/Tibber_Query/module.html
+++ b/Tibber_Query/module.html
@@ -97,7 +97,7 @@
         let HourAhead;
             
         let bars = document.getElementById("bars");
-        for(let i = 0; i < 24; i++) {
+        for(let i = 0; i < 48; i++) {
             let bar = document.createElement('div');
             bar.id = 'bar_' + i;
             bar.innerHTML = 'xx,xx&nbsp;&nbsp;';
@@ -106,7 +106,7 @@
         }
 
         let hours = document.getElementById("hours");
-        for(let i = 0; i < 24; i++) {
+        for(let i = 0; i < 48; i++) {
             let hour = document.createElement('div');
             hour.id = 'hour_' + i;
             hour.innerHTML = i;
@@ -115,7 +115,7 @@
 
         function handleMessage(message) {
                         
-            for(let i = 0; i < 24; i++) {
+            for(let i = 0; i < 48; i++) {
                 //document.getElementById('hour_' + i).className = "";
                 document.getElementById('hour_' + i).className = i;
             }
@@ -172,8 +172,7 @@
                     break;  
                     case 'FCHour':
                         root.style.setProperty('--FCHour', '#'+data[parameter]);
-                    break;  console.log(bar.style.height);
-
+                    break;
                     case 'BGCHour':
                         root.style.setProperty('--BGCHour', '#'+data[parameter]);
                     break;
@@ -198,7 +197,7 @@
                                 document.getElementById('block').innerHTML = data[parameter];
                                 document.getElementById('block').style.color = "red";
                                 console.log(NoData);
-                            };
+                            }
                     break; 
                     case 'Gradient':
                         root.style.setProperty('--Gradient', 'linear-gradient(to top,'+data[parameter]+')');
@@ -280,13 +279,13 @@
                                     }
                                 }
                                 // if less than 24 Hour is set, remove elements
-                                if (index >= HourAhead) {
+                                if (index > HourAhead) {
                                     document.getElementById('bar_' + index).remove();
                                     document.getElementById('hour_' + index).remove();
                                     }
 
                                 index++;
-                                if (index >= 24) {
+                                if (index >= 48) {
                                     break;
                                 }
                                 

--- a/Tibber_Query/module.json
+++ b/Tibber_Query/module.json
@@ -8,5 +8,5 @@
     "childRequirements": [],
     "implemented": [],
     "prefix": "TIBV2",
-    "url": ""
+    "url": "https://github.com/lorbetzki/net.lorbetzki.tibber.v2/blob/main/Tibber_Query/README.md"
 }

--- a/Tibber_Query/module.php
+++ b/Tibber_Query/module.php
@@ -21,6 +21,7 @@ require_once __DIR__ . '/../libs/functions.php';
 		private const HTML_Color_Darkgreen = 0x004000;
 		private const HTML_Default_PX = 5;
 		private const HTML_Default_HourAhead = 24;
+		private const HTML_Max_HourAhead = 48;
 		private const HTML_Bar_Price_Round = 2;
 		private const HTML_Bar_Price_vis_ct = true;
 		private const HTML_Hour_WriteMode = false;
@@ -443,7 +444,7 @@ require_once __DIR__ . '/../libs/functions.php';
 						$valuePrice = $value['Price'];
 						if ($data >= $h)
 						{
-							if ($dateIndex >=24){ break; }
+							if ($dateIndex >= self::HTML_Max_HourAhead){ break; }
 							$AVGPrice[] = $valuePrice;
 							$dateIndex++;
 						}
@@ -500,7 +501,7 @@ require_once __DIR__ . '/../libs/functions.php';
 			}
 			$count = count($result_array);
 			$this->SendDebug('Result_array', $count, 0);
-			if ($count <= 24){
+			if ($count <= self::HTML_Max_HourAhead){
 				AC_AddLoggedValues($this->ReadAttributeInteger("ar_handler"), $this->GetIDForIdent("Ahead_Price"), [[ 'TimeStamp' => mktime(00, 00, 01, intval( date("m") ) , intval(date("d")-1), intval(date("Y"))), 'Value' => 0 ]]);
 			}
 			AC_ReAggregateVariable($this->ReadAttributeInteger("ar_handler"), $this->GetIDForIdent("Ahead_Price"));
@@ -957,7 +958,7 @@ require_once __DIR__ . '/../libs/functions.php';
 			$result['BGCPriceE']					= "#".sprintf('%06X', $this->ReadPropertyInteger("HTML_BGColorPriceE"));
 			$result['BGCPriceVE']					= "#".sprintf('%06X', $this->ReadPropertyInteger("HTML_BGColorPriceVE"));
 			$result['PriceLevelThickness']			= $this->ReadPropertyInteger("HTML_PriceLevelThick");
-			$result['HourAhead']					= $this->ReadPropertyInteger("HTML_Default_HourAhead");
+			$result['HourAhead']					= min ($this->ReadPropertyInteger("HTML_Default_HourAhead"), $this->hoursUntilTomorrowMidnight());
 
 			$result['bar_price_round']				= $this->ReadPropertyInteger("HTML_Bar_Price_Round");
 			$result['bar_price_vis_ct']				= $this->ReadPropertyBoolean("HTML_Bar_Price_vis_ct");
@@ -970,6 +971,17 @@ require_once __DIR__ . '/../libs/functions.php';
 			return json_encode($result) ;
 		}
 
+        private function hoursUntilTomorrowMidnight(): int
+        {
+            $currentDateTime = new DateTime();
+
+            // übermorgen Mitternacht
+            $overTomorrowMidnight = new DateTime('+2 days midnight');
+
+            // Berechnung der Stunden bis übermorgen Mitternacht
+            $interval = $currentDateTime->diff($overTomorrowMidnight);
+            return ($interval->days * 24) + $interval->h;
+        }
 		public function GetFullUpdateMessageMANU()
 		{
 			//funktion um die Kachelvisu besser testen zu können.

--- a/Tibber_Realtime/module.json
+++ b/Tibber_Realtime/module.json
@@ -8,5 +8,5 @@
     "childRequirements": [],
     "implemented": ["{018EF6B5-AB94-40C6-AA53-46943E824ACF}"],
     "prefix": "TIBRTV2",
-    "url": ""
+    "url": "https://github.com/lorbetzki/net.lorbetzki.tibber.v2/blob/main/Tibber_Realtime/README.md"
 }

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "compatibility": {
         "version": "7.1"
     },
-    "version": "2.3.2",
-    "build": 20241110,
+    "version": "2.3.3",
+    "build": 20241206,
     "date": 0
 }


### PR DESCRIPTION
Hallo Kris,

hier ist der PR. Zwei Fehler sind noch drin, die ich noch nicht fixen konnte. Vielleicht magst du sie dir einmal ansehen und findest sie schneller. Sonst schau ich noch mal in Ruhe nach.

- die aktuelle Stunde ist auch am morgigen Tag hinterlegt. Das soll sicherlich nicht sein. Damit zusammen hängt wohl, dass der aktuelle Preis falsch angezeigt wird. Es ist vermutlich der von morgen 10 Uhr
- der letzte Zeitraum wird etwas abgeschnitten. Da kenn ich mich mit HTML nicht aus :-(

![image](https://github.com/user-attachments/assets/41051994-3a10-464f-bd47-3ecc45efabb0)

Burkhard